### PR TITLE
Add aurora token to tokens menu

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -110,6 +110,13 @@
                     class: "dropdown-item #{tab_status("accounts", @conn.request_path)}",
                     to: address_path(@conn, :index)
                   ) %>
+                <%= if aurora_token_contract_address() do %>
+                  <%= link(
+                      "AURORA",
+                      class: "dropdown-item",
+                      to: token_path(BlockScoutWeb.Endpoint, :show, aurora_token_contract_address())
+                    ) %>
+                <% end %>
             </div>
           </li>
         <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -47,6 +47,10 @@ defmodule BlockScoutWeb.LayoutView do
     Keyword.get(application_config(), :logo_text) || nil
   end
 
+  def aurora_token_contract_address do
+    Keyword.get(application_config(), :aurora_token_contract_address) || nil
+  end
+
   def subnetwork_title do
     Keyword.get(application_config(), :subnetwork) || "Sokol"
   end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,7 +67,8 @@ config :block_scout_web, BlockScoutWeb.Chain,
   has_emission_funds: false,
   show_maintenance_alert: System.get_env("SHOW_MAINTENANCE_ALERT", "false") == "true",
   enable_testnet_label: System.get_env("SHOW_TESTNET_LABEL", "false") == "true",
-  testnet_label_text: System.get_env("TESTNET_LABEL_TEXT", "Testnet")
+  testnet_label_text: System.get_env("TESTNET_LABEL_TEXT", "Testnet"),
+  aurora_token_contract_address: System.get_env("AURORA_TOKEN_CONTRACT_ADDRESS")
 
 verification_max_libraries_default = 10
 


### PR DESCRIPTION
```
export AURORA_TOKEN_CONTRACT_ADDRESS=0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79
```

If ENV variable exists, link to the aurora token contract will be shown
https://explorer.aurora.dev/token/0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79

![Mainnet Mainnet Explorer 2023-02-03 17-22-36](https://user-images.githubusercontent.com/1568885/216655296-1121bcfc-6b90-4e2f-8430-52117a15da88.jpg)
